### PR TITLE
bumping versions and WORKDIR set to deployer's home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM google/cloud-sdk:398.0.0-alpine@sha256:282aa5efa274bd99f2ede0b07807994525282c9d6facc764fc22521e521fae83
+FROM google/cloud-sdk:399.0.0-alpine@sha256:282aa5efa274bd99f2ede0b07807994525282c9d6facc764fc22521e521fae83
 ARG KUSTOMIZE_VERSION=4.5.7
 ARG SOPS_VERSION=3.7.3
-ARG HELM_VERSION=3.9.3
+ARG HELM_VERSION=3.9.4
 ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz /tmp
 ADD https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz /tmp
 RUN tar xf /tmp/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/bin && \
@@ -19,3 +19,4 @@ RUN gcloud components install gke-gcloud-auth-plugin && \
     addgroup -S deployer && adduser -S deployer -G deployer
 
 USER deployer
+WORKDIR /home/deployer

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ You can manually build the Docker image with the following command:
 docker buildx build . -t muehlemannpopp/gke-deploy-tools:latest \
        --build-arg KUSTOMIZE_VERSION=4.5.7 \
        --build-arg SOPS_VERSION=3.7.3      \
-       --build-arg HELM_VERSION=3.9.3
+       --build-arg HELM_VERSION=3.9.4
 ```
 
 # Push image
 
 ```bash
-docker tag muehlemannpopp/gke-deploy-tools:398.0.0 \
+docker tag muehlemannpopp/gke-deploy-tools:399.0.0 \
        muehlemannpopp/gke-deploy-tools:latest
-docker push muehlemannpopp/gke-deploy-tools:398.0.0
+docker push muehlemannpopp/gke-deploy-tools:399.0.0
 docker push muehlemannpopp/gke-deploy-tools:latest
 ```
 

--- a/README.org
+++ b/README.org
@@ -22,15 +22,15 @@ You can manually build the Docker image with the following command:
   docker buildx build . -t muehlemannpopp/gke-deploy-tools:latest \
          --build-arg KUSTOMIZE_VERSION=4.5.7 \
          --build-arg SOPS_VERSION=3.7.3      \
-         --build-arg HELM_VERSION=3.9.3
+         --build-arg HELM_VERSION=3.9.4
 #+end_src
 
 * Push image
 
 #+begin_src bash
-  docker tag muehlemannpopp/gke-deploy-tools:398.0.0 \
+  docker tag muehlemannpopp/gke-deploy-tools:399.0.0 \
          muehlemannpopp/gke-deploy-tools:latest
-  docker push muehlemannpopp/gke-deploy-tools:398.0.0
+  docker push muehlemannpopp/gke-deploy-tools:399.0.0
   docker push muehlemannpopp/gke-deploy-tools:latest
 #+end_src
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,4 @@
 {
-
   outputs = { self, nixpkgs }:
     let pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in {


### PR DESCRIPTION
- WORKDIR set to `home/deployer`
- google/cloud-sdk bumped to v399.0.0
- Helm bumped to v3.9.4