### PR TITLE
bumping dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM google/cloud-sdk:402.0.0-alpine@sha256:20ec5831f167b1e1283348a98651b1068fa46cabad4c349758be75038e55df8a
+FROM google/cloud-sdk:403.0.0-alpine@sha256:3791683bade5ec26f37527d09cd531a617c0fb96da89154eb2b0484c97020f4a
 ARG KUSTOMIZE_VERSION=4.5.7
 ARG SOPS_VERSION=3.7.3
-ARG HELM_VERSION=3.9.4
+ARG HELM_VERSION=3.10.0
 ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz /tmp
 ADD https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz /tmp
 RUN tar xf /tmp/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/bin && \
@@ -9,7 +9,7 @@ RUN tar xf /tmp/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/bin &
     wget https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64 -O /usr/bin/sops && \
     chmod a+x /usr/bin/sops
 
-FROM google/cloud-sdk:402.0.0-alpine@sha256:20ec5831f167b1e1283348a98651b1068fa46cabad4c349758be75038e55df8a
+FROM google/cloud-sdk:403.0.0-alpine@sha256:3791683bade5ec26f37527d09cd531a617c0fb96da89154eb2b0484c97020f4a
 COPY --from=0 /usr/bin/kustomize /usr/bin/kustomize
 COPY --from=0 /usr/bin/linux-amd64/helm /usr/bin/helm
 COPY --from=0 /usr/bin/sops /usr/bin/sops

--- a/README.org
+++ b/README.org
@@ -59,9 +59,9 @@ https://hub.docker.com/r/google/cloud-sdk/tags
 #+end_src
 
 #+RESULTS: get-latest-cloud-sdk-tag
-Latest alpine image tag is =402.0.0-alpine= updated at /2022-09-14T14:44:28.483417Z/.
+Latest alpine image tag is =403.0.0-alpine= updated at /2022-09-23T15:06:30.03001Z/.
 
-The digest is =sha256:20ec5831f167b1e1283348a98651b1068fa46cabad4c349758be75038e55df8a=.
+The digest is =sha256:3791683bade5ec26f37527d09cd531a617c0fb96da89154eb2b0484c97020f4a=.
 
 ** Kustomize
 
@@ -125,4 +125,4 @@ https://github.com/helm/helm/releases
 #+end_src
 
 #+RESULTS: get-latest-helm-release
-Latest Helm release is =Helm 3.9.4= published at /2022-08-24T20:00:15Z/.
+Latest Helm release is =Helm 3.10.0= published at /2022-09-21T17:32:35Z/.


### PR DESCRIPTION
Helm updated to 3.10.0 and cloud-sdk updated to 403.0.0